### PR TITLE
Improve link between user and registries

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,9 +40,7 @@ class User < ApplicationRecord
   end
 
   def link_registries
-    registries = Registry.where(email: email.downcase)
-
-    registries.each do |registry|
+    Registry.where(email: email.downcase.strip).find_each do |registry|
       registry.user = self
       registry.guests.each { |g| g.presence = nil }
       registry.save


### PR DESCRIPTION
When user subscribed with his email, we want to avoid
trailing white spaces (registries emails are prompted by admin user).