### PR TITLE
Disable welcome mail

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,12 +10,8 @@ class User < ApplicationRecord
   has_many :registries
   has_many :messages, dependent: :destroy
 
-
-
   after_create :link_registries
   has_attachment :avatar, accept: [:jpg, :png, :gif, :jpeg]
-
-
 
   def self.find_for_facebook_oauth(auth)
     user_params = auth.slice(:provider, :uid)
@@ -34,8 +30,7 @@ class User < ApplicationRecord
       user.password = Devise.friendly_token[0,20]  # Fake password for validation
       user.save
     end
-
-    return user
+    user
   end
 
   def link_registries
@@ -53,5 +48,4 @@ protected
   def send_welcome_email
     UserMailer.welcome(self).deliver_now
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,6 @@ class User < ApplicationRecord
 
 
 
-  after_create :send_welcome_email
   after_create :link_registries
   has_attachment :avatar, accept: [:jpg, :png, :gif, :jpeg]
 
@@ -48,6 +47,8 @@ class User < ApplicationRecord
       registry.save
     end
   end
+
+protected
 
   def send_welcome_email
     UserMailer.welcome(self).deliver_now


### PR DESCRIPTION
Actually, there is no mailer defined, we don't want to send  (or display) emails for new user (created form seeds for example).
This feature should be reactivated when necessary