### PR TITLE
Enhance environement variables for Google API

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     </div>
 
 
-      <%= javascript_include_tag "https://maps.google.com/maps/api/js?libraries=places&key=#{ENV['GOOGLE_API_SERVER_KEY']}" %>
+      <%= javascript_include_tag "https://maps.google.com/maps/api/js?libraries=places&key=#{ENV["GOOGLE_API_KEY_FRONTED"]}" %>
       <%= javascript_include_tag "https://cdn.rawgit.com/printercu/google-maps-utility-library-v3-read-only/master/markerclusterer/src/markerclusterer_compiled.js" %>
       <%= javascript_include_tag "https://cdn.rawgit.com/printercu/google-maps-utility-library-v3-read-only/master/infobox/src/infobox_packed.js" %>
 

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path('../../Gemfile', __FILE__)
 load Gem.bin_path('bundler', 'bundle')

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,3 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/config/database.yml
+++ b/config/database.yml
@@ -76,10 +76,12 @@ test:
 # You can use this database configuration with:
 #
 #   production:
-#     url: <%= ENV['DATABASE_URL'] %>
+#     url: <%= ENV["DATABASE_URL"] %>
 #
+
+# TODO : do we need a password on db production ???
 production:
   <<: *default
   database: mariage-participatif_production
   username: mariage-participatif
-  password: <%= ENV['MARIAGE-PARTICIPATIF_DATABASE_PASSWORD'] %>
+  password: <%= ENV["MARIAGE-PARTICIPATIF_DATABASE_PASSWORD"] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,7 @@
 Rails.application.configure do
 
   config.action_mailer.delivery_method = :postmark
-  config.action_mailer.postmark_settings   = { api_key: ENV['POSTMARK_API_KEY'] }
+  config.action_mailer.postmark_settings   = { api_key: ENV["POSTMARK_API_KEY"] }
   config.action_mailer.default_url_options = { host: "http://www.mariage-participatif.fr" }
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,22 +1,6 @@
 Geocoder.configure(
-  # Geocoding options
-  # timeout: 3,                 # geocoding service timeout (secs)
-  lookup: :google,            # name of geocoding service (symbol)
-  # ip_lookup: :freegeoip,      # name of IP address geocoding service (symbol)
-  # language: :en,              # ISO-639 language code
-  use_https: true,           # use HTTPS for lookup requests? (if supported)
-  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
-  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
-  api_key: ENV['GOOGLE_API_SERVER_KEY'],               # API key for geocoding service
-  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
-  # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
-
-  # Exceptions that should not be rescued by default
-  # (if you want to implement custom error handling);
-  # supports SocketError and Timeout::Error
-  # always_raise: [],
-
-  # Calculation options
-  units: :km,                 # :km for kilometers or :mi for miles
-  # distances: :linear          # :spherical or :linear
+  lookup: :google,
+  use_https: true,
+  api_key: ENV["GOOGLE_API_KEY_BACKEND"],
+  units: :km,
 )


### PR DESCRIPTION
Rename environement variables, distinction between:
- `GOOGLE_API_KEY_BACKEND` : no restriction, for Geocoder
- `GOOGLE_API_KEY_FRONTEND` : with http referrer restrictions

Favor double-quotes for every environment variables