### PR TITLE
Move tasks list to dedicated page

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,7 +7,7 @@ class TasksController< ApplicationController
 
 
   def index
-    @tasks = Task.where('wedding_id = ?', @wedding.id)
+    @tasks = Task.where wedding: @wedding
   end
 
 
@@ -129,7 +129,4 @@ private
       end
     end
   end
-
-
-
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -4,6 +4,8 @@ class Service < ApplicationRecord
   has_many :guests
 
   validates :name, presence: true
+  validates :capacity,
+    numericality: { only_integer: true, greater_than_or_equal_to: 1 }
 
   def is_service_complete?
     guests.count == capacity

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -17,8 +17,18 @@ class Task < ApplicationRecord
     messages.where(read: false).count
   end
 
+  def required_guests_quantity
+    return unless services.any?
+    services.map{ |s| s.capacity - s.guests.count }.sum
+  end
+
   def unread_messages_count_to_display
     return "" unless unread_messages_count > 0
     "#{unread_messages_count} message#{unread_messages_count > 1 ? "s" : ""}"
+  end
+
+  def required_guests_quantity_to_display
+    return "service complet :)" if required_guests_quantity.zero?
+    "encore #{required_guests_quantity} personnes"
   end
 end

--- a/app/views/tasks/_tasks.html.erb
+++ b/app/views/tasks/_tasks.html.erb
@@ -1,32 +1,5 @@
 <h3 class="text-center">
-  <span class="section-title">Inscriptions aux services et discussions dédiées</span>
-</h3>
-
-<div class= tasklist>
-  <ul class="tasks">
-    <div class="row extra-width">
-      <% wedding.tasks_with_service.each do |task| %>
-        <%= link_to wedding_task_path(wedding, task) do %>
-          <div class="col-xs-6 cos-sm-3 col-md-2">
-            <li class="task">
-              <div class="taskname button">
-                <strong> <%= task.name %> </strong>
-                <div class="tasknotification">
-                  <% if policy(@wedding).edit? %>
-                    <%= task.unread_messages_count_to_display %>
-                  <% end %>
-                </div>
-              </div>
-            </li>
-          </div>
-        <% end %>
-      <% end %>
-    </div>
-  </ul>
-</div>
-
-<h3 class="text-center">
-  <span class="section-title">Autres discussions</span>
+  <span class="section-title">Espace de libre échange</span>
 </h3>
 
 <div class= tasklist>
@@ -63,32 +36,12 @@
 
 <div class="text-center">
   <% if policy(@wedding).edit? %>
-    <div>
-      <%= link_to new_wedding_task_path(@wedding), class: "button button-show" do %>
-        Créer une nouvelle discussion
-      <% end %>
-    </div>
+    <%= link_to new_wedding_task_path(@wedding), class: "button button-show" do %>
+      Créer une nouvelle discussion
+    <% end %>
+  <% else %>
+    <%= link_to new_wedding_task_path(@wedding), class: "button button-show" do %>
+      Proposer une nouvelle discussion
+    <% end %>
   <% end %>
 </div>
-
-
-
-<!-- pour ajouter icons
-
-
-<script>
-
-
-
-
-const list = document.getElementById("tasks-list")
-const taskItems = list.querySelectorAll("l")
-
-console.log(taskItems);
-
-taskItems.addEventListener("click", (event) => {
-  event.currentTarget.toggleClass("active")
-});
-
-</script>
- -->

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,21 +1,49 @@
-<div id="task-container">
-    <% if policy(@wedding).edit? %>
+<div class="container">
 
-      <% if @wedding.tasks.empty? %>
-        <%= link_to "Create your first task", new_wedding_task_path(@wedding) %>
-      <% else %>
-        <% nb_tasks = @wedding.tasks.size %>
-        <p> They are <%= nb_tasks %> tasks for your wedding ! Here is the list :</p>
-        <ul>
-          <% @wedding.tasks.each_with_index do |t, ind| %>
-            <li><%= "Task n°#{ind + 1} : #{t.name}" %> </li>
-            <%= link_to "show this task", wedding_task_path(@wedding, t) %>
-          <% end %>
-        </ul>
-        <p>
-          <%= link_to "Add a new task", new_wedding_task_path(@wedding) %>
-        </p>
-      <% end %>
-    <% end %>
-  <%= link_to "Back to wedding", wedding_path(@wedding) %>
+  <div class="text-center">
+    <h3>
+      <span class="section-title">Inscription aux services</span>
+    </h3>
+    <p> Ci-dessous, la liste des services pour lesquels on a besoin de votre aide, rangés par catégorie.
+    <br>
+    Si vous êtes partant pour participer en nous donnant un coup de main le jour J, on vous laisse choisir le votre.
+    <br>
+    </p>
   </div>
+
+  <div class="tasks-bloc">
+    <div class= tasklist>
+      <ul class="tasks">
+        <div class="row extra-width">
+          <% @wedding.tasks_with_service.each do |task| %>
+            <%= link_to wedding_task_path(@wedding, task) do %>
+              <div class="col-xs-6 cos-sm-3 col-md-2">
+                <li class="task">
+                  <div class="taskname button">
+                    <strong> <%= task.name %> </strong>
+                    <div class="tasknotification">
+                      <%= task.required_guests_quantity_to_display %>
+                      <% if policy(@wedding).edit? %>
+                        <%= task.unread_messages_count_to_display %>
+                      <% end %>
+                    </div>
+                  </div>
+                </li>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      </ul>
+    </div>
+  </div>
+
+  <div class="links">
+    <%= link_to t("links.back"), wedding_path(@wedding) %>
+  </div>
+
+  <div class="text-center">
+    Choisir un service est une propositon que nous vous faisons, pas une obligation.
+    <br>
+    Si vous ne pouvez pas choisir de service, pas la peine de bouder. Venez profiter, on compte sur vous tout autant !
+  </div>
+</div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -4,7 +4,8 @@
   </h3>
 
   <div class="links padding-down">
-    <%= link_to t("links.back"), wedding_path(@wedding), class: "back-link" %>
+    <%= link_to t("links.back"), wedding_tasks_path(@wedding), class: "back-link" %>
+    <%= link_to t("links.back_to_wedding"), wedding_path(@wedding), class: "back-link" %>
     <% if policy(@wedding).edit? %>
       <%= link_to t("links.destroy"), wedding_task_path(@wedding, @task), method: :delete, data: { confirm: t("links.confirmation") } %>
     <% end %>

--- a/app/views/weddings/_guest-blocks.html.erb
+++ b/app/views/weddings/_guest-blocks.html.erb
@@ -32,7 +32,7 @@
           <% end %>
         </ul>
         <div class="button-container">
-          <a class="button button-show" href="#task-discussion-container">Liste des services</a>
+          <%= link_to "Voir liste", wedding_tasks_path(@wedding), class: "button button-show" %>
           <% unless @registry.services.count == 0 %>
             <%= link_to "Vos services", wedding_services_path(@wedding), class: "button button-show" %>
           <% end %>

--- a/app/views/weddings/_wedder-blocks.html.erb
+++ b/app/views/weddings/_wedder-blocks.html.erb
@@ -35,7 +35,8 @@
             <li>Nombre d'invités nécessaire : <%= @wedding.guests_needed_for_service_count %>  </li>
           </ul>
           <div class="button-container">
-            <%= link_to "Detail services", wedding_services_path(@wedding), class: "button button-show" %>
+            <%= link_to "Liste services", wedding_tasks_path(@wedding), class: "button button-show" %>
+            <%= link_to "Synthèse inscriptions", wedding_services_path(@wedding), class: "button button-show" %>
           </div>
       </div>
     </div>


### PR DESCRIPTION
Use `tasks#index` to display tasks, and some services information.

On `wedding#show`, display only tasks without service
(they could be renamed to 'article', or 'discussion', in dedicated PR)

Clean some dead or wrong code when it's possible