### PR TITLE
Define cloudinary storage regarding environments

### DIFF
--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -1,7 +1,17 @@
 class PhotoUploader < CarrierWave::Uploader::Base
   include Cloudinary::CarrierWave
 
+  def public_id
+    cloudinary_folder + model.class.name
+  end
+
   def extension_whitelist
     %w(jpg jpeg gif png)
+  end
+
+private
+
+  def cloudinary_folder
+    MariageParticipatif::CloudinaryStoreDir
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ require "sprockets/railtie"
 Bundler.require(*Rails.groups)
 
 
-module MariEtVous
+module MariageParticipatif
   class Application < Rails::Application
     config.generators do |generate|
       generate.assets false
@@ -32,4 +32,6 @@ module MariEtVous
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
   end
+
+  CloudinaryStoreDir = ENV.fetch "CLOUDINARY_STORE_DIR", "development/"
 end


### PR DESCRIPTION
Define environment variable `CLOUDINARY_STORE_DIR` to "production/" on `production`.

If we want  to upload images from review-app, we need to define :
- `CLOUDINARY_STORE_DIR`
- `CLOUDINARY_URL`

Of course, project name is `MariageParticipatif`, not `MariEtVous` 