### PR TITLE
Improve models Service

### DIFF
--- a/app/assets/stylesheets/components/_links.scss
+++ b/app/assets/stylesheets/components/_links.scss
@@ -1,7 +1,7 @@
 .button-show {
-      display: block;
-      width: 100%;
-    }
+  display: block;
+  width: 100%;
+}
 
 .links {
   padding-top: 20px;
@@ -27,10 +27,6 @@
   color: #726e6e !important;
 }
 
-
-.links a:nth-child(n+2){
+.links a:nth-child(n+2) {
   border-left: 1px solid $p-grey;
-    }
-
-
-
+}

--- a/app/assets/stylesheets/components/_service.scss
+++ b/app/assets/stylesheets/components/_service.scss
@@ -32,6 +32,10 @@
       }
     }
 
+    a {
+      font-style: italic;
+      font: #726e6e;
+    }
 }
 
 .service-registrations {
@@ -49,7 +53,7 @@
     }
 }
 
-#complete {
+.complete {
 
     li {
       font-size: 16px !important;
@@ -61,4 +65,8 @@
 .service-links {
     flex: 0 0 10%;
     padding: 5px;
+}
+
+.service-button {
+  font-size: 15px;
 }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -17,8 +17,7 @@ class TasksController< ApplicationController
 
     @message = Message.new
 
-    @list_guests_adults = current_user.registries.last.guests.where(child: false).where(presence: true) unless current_user == @wedding.user
-    @list_guests_adults_without_service = @list_guests_adults.select { |g| !g.service_id?  } unless current_user == @wedding.user
+    @guests_without_service = guests_without_service
   end
 
   def create
@@ -63,5 +62,12 @@ private
 
   def task_params
     params.require(:task).permit(:name)
+  end
+
+  def guests_without_service
+    return if policy(@wedding).edit?
+    current_user.registry_for_wedding(@wedding)
+      .guests
+      .where_service_is_required
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  DAYS_NAME = %w[lundi mardi mercredi jeudi vendredi samedi dimanche]
+
   def avatar_for(user, options = {})
     if user.avatar.present?
       cl_image_tag user.avatar, options
@@ -27,5 +29,10 @@ module ApplicationHelper
     else
       "#{icon("far", "times-circle")} Non".html_safe
     end
+  end
+
+  def day_to_display(week_day)
+    return unless (0..6).include? week_day
+    DAYS_NAME[week_day]
   end
 end

--- a/app/models/guest.rb
+++ b/app/models/guest.rb
@@ -3,4 +3,9 @@ class Guest < ApplicationRecord
   belongs_to :service, optional: true
 
   validates :name, presence: true
+
+  def self.where_service_is_required
+    # TODO : adapt sql, one where clause should be enough
+    where(child: false).where(presence: true).where(service_id: nil)
+  end
 end

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -13,7 +13,7 @@ class Registry < ApplicationRecord
   def update_score!
     score = 1
     score += guests.where(presence: nil).empty? ? 33 : 0
-    score += ((services.count == guests.where(child: false).where(presence: true).count) && guests.where(presence: nil).empty?) ? 33 : 0
+    score += (services.count == guests.where_service_is_required) ? 33 : 0
     score += (!vegetables.empty? && guests.where(presence: nil).empty?) ? 33 : 0
     update! score_registry: score
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -2,15 +2,23 @@ class Service < ApplicationRecord
   belongs_to :task
   has_many :guests
 
-  validates :name, presence: true
+  validates :description, presence: true
   validates :capacity,
-    numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+    numericality: { only_integer: true, greater_than: 0 }
 
-  def is_service_complete?
-    guests.count == capacity
+  def remaining_places_count
+    capacity - guests.count
   end
 
-  def is_service_over_capacity?
-    guests.count > capacity
+  def is_service_complete?
+    remaining_places_count.zero?
+  end
+
+  def schedule
+    [start_at.strftime("%H h %M"), stop_at.strftime("%H h %M")].join(" - ")
+  end
+
+  def week_day
+    start_at.strftime("%u").to_i - 1
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,11 @@ class User < ApplicationRecord
     end
   end
 
+  def registry_for_wedding(wedding)
+    # NOTE : add uniqueness validation, one registry per user & per wedding
+    registries.where(wedding_id: wedding.id).last
+  end
+
 protected
 
   def send_welcome_email

--- a/app/views/services/_form-service.html.erb
+++ b/app/views/services/_form-service.html.erb
@@ -1,14 +1,16 @@
-<%= simple_form_for([@wedding, @task, @service]) do |f| %>
-
-
-  <%= f.input :details, as: :text %>
-  <%= f.input :capacity %>
-  <%= f.input :day %>
-  <%= f.input :appointment %>
-  <%= f.input :location %>
-
-  <%= f.button :submit, "Valider" %>
-
-<% end %>
-
-
+<div class="container">
+  <div class="form-center">
+    <div class="row">
+      <div class="col-xs-12 col-sm-8 col-sm-offset-2">
+        <%= simple_form_for([@wedding, @task, @service]) do |f| %>
+          <%= f.input :description, as: :text %>
+          <%= f.input :capacity %>
+          <%= f.input :location %>
+          <%= f.input :start_at %>
+          <%= f.input :stop_at %>
+          <%= f.button :submit, "Valider" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,40 +1,60 @@
 <div class="container">
-
-  <% if policy(@wedding).edit? %>
-    <p>Coucou les mariés ! Vous voulez voir la liste des services ? Désolé, mais le mieux, et de passer par votre BDD Excel, ou de passer par les categories / discussions </p>
-    <p>Sur cette page, un invité voit le service auquel il est inscrit</p>
-
-  <% else %>
-
-    <p><%= @services.count %> services !</p>
+  <% if @services.any? && !policy(@wedding).edit? %>
+    <p>
+      Vous avez choisi
+      <% if @services.count > 1 %>
+        <%= @services.count %> services,
+      <% else %>
+        <%= @services.count %> service,
+      <% end %>
+      merci !
+    </p>
     <div class="fullblock">
-      <% if @services.count > 0 %>
+      <% if @services.any? %>
         <div class="col-xs-12 task-details">
-          <% @guests.each do |g| %>
-            <h4><%= g.name %> :</h4>
-            <% if g.service_id? %>
+          <% @guests.each do |guest| %>
+            <h4><%= guest.name %> :</h4>
+            <% if guest.service %>
               <div class="service-card">
                 <div class="service-description">
-                  <%= g.service.details %>
+                  <%= guest.service.description %>
                 </div>
 
                 <div class="service-details">
                   <ul>
-                    <li><%= icon("far", "calendar") %><%= g.service.day %></li>
-                    <li><%= icon("far", "clock") %><%= g.service.appointment %></li>
-                    <li><%= icon("fas", "map-marker-alt") %><%= g.service.location %></li>
+                    <li>
+                      <%= icon("far", "calendar") %>
+                      <%= day_to_display guest.service.week_day %>
+                    </li>
+                    <li>
+                      <%= icon("far", "clock") %>
+                      <%= guest.service.schedule %>
+                    </li>
+                    <li>
+                      <%= icon("fas", "map-marker-alt") %>
+                      <%= guest.service.location %>
+                    </li>
                   </ul>
                 </div>
 
-                <% if g.service.is_service_complete? %>
-                  <div class="service-registrations" id="complete">
+                <% if guest.service.is_service_complete? %>
+                  <div class="service-registrations complete">
                     <ul>
                       <li>Service complet !</li>
                       <div class="dropdown">
-                        <a href="" class="dropdown-toggle" id="service-registration-guests-list" data-toggle="dropdown"><%= "#{g.service.guests.count} inscrits !"%></a>
+                        <a href="" class="dropdown-toggle" id="service-registration-guests-list" data-toggle="dropdown">
+                          <% if guest.service.guests.count > 2 %>
+                            <%="#{guest.service.guests.count - 1} autres volontaires"%>
+                          <% else %>
+                            <%="#{guest.service.guests.count - 1} autre volontaire"%>
+                          <% end %>
+                        </a>
                         <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
-                          <% g.service.guests.each do |guest| %>
-                            <li><%= "#{guest.registry.group_name.capitalize}, #{guest.name} " %></li>
+                          <% guest.service.guests.each do |other_guest| %>
+                            <% next if guest == other_guest %>
+                            <li>
+                              <%= "#{other_guest.registry.group_name.capitalize}, #{other_guest.name}" %>
+                            </li>
                           <% end %>
                         </ul>
                       </div>
@@ -43,20 +63,34 @@
                 <% else %>
                   <div class="service-registrations">
                     <ul>
-                      <li><%= "#{g.service.capacity - g.service.guests.count} place(s)" %></li>
-                      <li><%= "#{g.service.guests.count} inscrits"%></li>
+                      <li><%= "déjà #{guest.service.guests.count} volontaires,"%></li>
+                      <li>
+                        <% if guest.service.remaining_places_count > 1 %>
+                          <%= "il reste #{guest.service.remaining_places_count} places." %>
+                        <% else %>
+                          <%= "il reste #{guest.service.remaining_places_count} place." %>
+                        <% end %>
+                      </li>
                     </ul>
                   </div>
                 <% end %>
                 <div class="service-links">
                   <ul>
-                    <li>Catégorie:</li>
-                    <li><%= link_to g.service.task.name, wedding_task_path(@wedding, g.service.task) %></li>
+                    <li>
+                      <%= link_to wedding_task_path(@wedding, guest.service.task) do %>
+                        <%= icon("far", "envelope") %>
+                      <% end %>
+                    </li>
                   </ul>
                 </div>
               </div>
             <% else %>
-              <p>Pas encore de service</p>
+              <p>Pas encore de service ?</p>
+              <p>
+                <%= link_to wedding_tasks_path(@wedding), class: "button service-button" do %>
+                  Voir la liste
+                <% end %>
+              </p>
             <% end %>
           <% end %>
         </div>
@@ -68,5 +102,3 @@
     <%= link_to t("links.back"), wedding_path(@wedding), class: "back-link" %>
   </div>
 </div>
-
-

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -13,12 +13,12 @@
 
   <div class="fullblock">
     <div class="statut">
-      <% if @services.count > 0 %>
+      <% if @services.any? %>
         <p>
           <% if @task.statut %>
-            <i class="fa fa-check"></i>
+            <%= icon("far", "check") %>
           <% else %>
-            <i class="fa fa-hourglass-half"></i>
+            <%= icon("fa", "hourglass-half") %>
           <% end %>
 
           <%= @task.statut ? t("task.done") : t("task.not_done") %>
@@ -29,19 +29,16 @@
             <% else %>
               <%= link_to t("task.mark"), edit_wedding_task_path(@wedding, @task) %>
             <% end %>
-            <%= link_to "|     Ajouter un service", new_wedding_task_service_path(@wedding, @task)%>
+            <%= link_to "| Ajouter un service", new_wedding_task_service_path(@wedding, @task)%>
           <% end %>
         </p>
       <% end %>
     </div>
 
-
-
-
     <div class="row">
       <!-- Vu par les mariés -->
       <% if policy(@wedding).edit? %>
-        <% if @services.count > 0 %>
+        <% if @services.any? %>
           <div class="col-xs-12 task-details">
           <h4><%= t("task.list")%></h4>
             <div class="rightblock bloc">
@@ -50,18 +47,33 @@
                 <li>
                   <div class="service-card">
                     <div class="service-description">
-                      <%= service.details %>
+                      <%= service.description %>
                     </div>
                     <div class="service-details">
                       <ul>
-                        <li><%= icon("far", "calendar") %><%= service.day %></li>
-                        <li><%= icon("far", "clock") %></i><%= service.appointment %></li>
-                        <li><%= icon("fas", "map-marker-alt") %><%= service.location %></li>
+                        <li>
+                          <%= icon("far", "calendar") %>
+                          <%= day_to_display service.week_day %>
+                        </li>
+                        <li>
+                          <%= icon("far", "clock") %>
+                          <%= service.schedule %>
+                        </li>
+                        <li>
+                          <%= icon("fas", "map-marker-alt") %>
+                          <%= service.location %>
+                        </li>
+                        <li>
+                          <%= link_to edit_wedding_task_service_path(@wedding, @task, service) do%>
+                            <%= icon("far", "edit") %>
+                            Modifier
+                          <% end %>
+                        </li>
                       </ul>
                     </div>
 
                     <% if service.is_service_complete? %>
-                      <div class="service-registrations" id="complete">
+                      <div class="service-registrations complete">
                         <ul>
                           <li>Service complet !</li>
                           <div class="dropdown">
@@ -77,7 +89,7 @@
                     <% else %>
                       <div class="service-registrations">
                         <ul>
-                          <li><%= "#{service.capacity - service.guests.count} place(s)" %></li>
+                          <li><%= "#{service.remaining_places_count} place(s)" %></li>
                           <li>
                             <div class="dropdown">
                               <a href="" class="dropdown-toggle" data-toggle="dropdown" ><%= "#{service.guests.count} inscrits"%></a>
@@ -100,7 +112,7 @@
         <% end %>
 
         <div class="col-xs-12 discussion">
-          <h4>Espace d'échange</h4>
+          <h4>On échange ?</h4>
           <div class="downblock bloc">
             <%= render "messages/messages-box", resource: @task %>
           </div>
@@ -108,27 +120,35 @@
 
       <% else %>
       <!-- Vue par les invités -->
-        <% if @services.count > 0 %>
+        <% if @services.any? %>
           <div class="col-xs-12 task-details">
             <h4><%= t("task.list")%></h4>
-              <div class="rightblock bloc">
-                <ul>
+            <div class="rightblock bloc">
+              <ul>
                 <% @services.each do |service| %>
                   <li>
                     <div class="service-card">
                       <div class="service-description">
-                        <%= service.details %>
+                        <%= service.description %>
                       </div>
                       <div class="service-details">
-                        <ul>
-                          <li><%= icon("far", "calendar") %><%= service.day %></li>
-                          <li><%= icon("far", "clock") %><%= service.appointment %></li>
-                          <li><%= icon("fas", "map-marker-alt") %><%= service.location %></li>
-                        </ul>
-                      </div>
-
+                      <ul>
+                        <li>
+                          <%= icon("far", "calendar") %>
+                          <%= day_to_display service.week_day %>
+                        </li>
+                        <li>
+                          <%= icon("far", "clock") %>
+                          <%= service.schedule %>
+                        </li>
+                        <li>
+                          <%= icon("fas", "map-marker-alt") %>
+                          <%= service.location %>
+                        </li>
+                      </ul>
+                    </div>
                       <% if service.is_service_complete? %>
-                        <div class="service-registrations" id="complete">
+                        <div class="service-registrations complete">
                           <ul>
                             <li>Service complet !</li>
                           </ul>
@@ -137,16 +157,16 @@
                           <div class="dropdown">
                             <a href="" class="dropdown-toggle" id="service-registration-guests-list" data-toggle="dropdown"><%= "#{service.guests.count} inscrits !"%></a>
                             <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
-                            <% service.guests.each do |guest| %>
-                              <li><%= "#{guest.registry.group_name.capitalize}, #{guest.name} " %></li>
-                            <% end %>
+                              <% service.guests.each do |guest| %>
+                                <li><%= "#{guest.registry.group_name.capitalize}, #{guest.name} " %></li>
+                              <% end %>
                             </ul>
                           </div>
                         </div>
                       <% else %>
                         <div class="service-registrations">
                           <ul>
-                            <li><%= "#{service.capacity - service.guests.count} place(s)" %></li>
+                            <li><%= "#{service.remaining_places_count} place(s)" %></li>
                             <li>
                               <div class="dropdown">
                                 <a href="" class="dropdown-toggle" data-toggle="dropdown" ><%= "#{service.guests.count} inscrits"%></a>
@@ -164,7 +184,7 @@
                             <a href="" class="dropdown-toggle" id="service-registration-guests-list" data-toggle="dropdown"> Inscription </a>
                             <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
                               <%= simple_form_for([@wedding, @task, service]) do |f| %>
-                                <%= f.association :guests, collection: @list_guests_adults_without_service, as: :check_boxes %>
+                                <%= f.association :guests, collection: @guests_without_service, as: :check_boxes %>
                                 <%= f.button :submit %>
                               <% end %>
                             </ul>
@@ -174,22 +194,19 @@
                     </div>
                   </li>
                 <% end %>
-                </ul>
-              </div>
-            </div>
-          <% end %>
-
-          <div class="col-xs-12 discussion">
-            <h4><%= t("task.messages") %></h4>
-            <p>Espace dédié pour parler (entre autre) de : "<%= @task.name %>" </p>
-            <div class="downblock bloc">
-                <%= render "messages/messages-box", resource: @task %>
+              </ul>
             </div>
           </div>
+        <% end %>
+
+        <div class="col-xs-12 discussion">
+          <h4><%= t("task.messages") %></h4>
+          <p>On échange ?</p>
+          <div class="downblock bloc">
+            <%= render "messages/messages-box", resource: @task %>
+          </div>
+        </div>
       <% end %>
     </div>
-
   </div>
 </div>
-
-

--- a/app/views/weddings/_wedder-blocks.html.erb
+++ b/app/views/weddings/_wedder-blocks.html.erb
@@ -35,8 +35,9 @@
             <li>Nombre d'invités nécessaire : <%= @wedding.guests_needed_for_service_count %>  </li>
           </ul>
           <div class="button-container">
-            <%= link_to "Liste services", wedding_tasks_path(@wedding), class: "button button-show" %>
-            <%= link_to "Synthèse inscriptions", wedding_services_path(@wedding), class: "button button-show" %>
+            <%= link_to wedding_tasks_path(@wedding), class: "button button-show" do %>
+              Voir les services
+            <% end %>
           </div>
       </div>
     </div>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -148,13 +148,14 @@ fr:
         presence: Presence
         child: Enfant ?
       service:
-        guests: Inscrire
         name: Catégorie
-        details: Description
-        capacity: Nb de personnes nécessaires
-        day: Jour
+        dsecription: Description
+        capacity: Nombre de personnes nécessaires
         location: Lieu
         appointment: Créneau
+        start_at: de
+        stop_at: à
+
       question:
         name: Votre nom
         email: Votre email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
     resources :vegetables, only: [:index]
     resources :accomodations, only: [:index]
     resources :tasks do
-      resources :services, only: [:new, :create, :update, :destroy]
+      resources :services, only: [:new, :create, :edit, :update]
     end
     resources :messages, only: [:create]
     resources :services, only: [:index]

--- a/db/migrate/20191110140616_add_start_at_and_stop_at_to_services.rb
+++ b/db/migrate/20191110140616_add_start_at_and_stop_at_to_services.rb
@@ -1,0 +1,12 @@
+class AddStartAtAndStopAtToServices < ActiveRecord::Migration[5.2]
+  def change
+    add_column :services, :start_at, :datetime
+    add_column :services, :stop_at, :datetime
+    add_column :services, :description, :string
+
+    remove_column :services, :day
+    remove_column :services, :appointment
+    remove_column :services, :name
+    remove_column :services, :details
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_21_145635) do
+ActiveRecord::Schema.define(version: 2019_11_10_140616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,15 +91,14 @@ ActiveRecord::Schema.define(version: 2019_09_21_145635) do
   end
 
   create_table "services", id: :serial, force: :cascade do |t|
-    t.string "name"
     t.integer "capacity"
     t.integer "task_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "appointment"
-    t.string "day"
     t.string "location"
-    t.string "details"
+    t.datetime "start_at"
+    t.datetime "stop_at"
+    t.string "description"
     t.index ["task_id"], name: "index_services_on_task_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,13 +54,12 @@ puts "creation de 2 taches, 2 services chacune"
   )
   2.times do |i|
     Service.create!(
-      name: "#{task_title} service #{i + 1}",
+      description: "#{task_title} service #{i + 1}",
       capacity: i + 1,
       task: task,
-      appointment: "1#{i + 1}h - 1#{i + 3}h",
-      day: "samedi",
       location: "ici",
-      details: "des détails",
+      start_at: Time.new(2020, 7, 1, 10 + i),
+      stop_at: Time.new(2020, 7, 1, 11 + i)
     )
   end
 end
@@ -100,7 +99,7 @@ puts "Creation des 2 guests adultes & 1 adulte absent & 1 enfant pour invitation
     name: "adulte A #{i + 1}",
     child: false,
     presence:true,
-    service: Service.find_by!(name: "Cuisine service 2")
+    service: Service.find_by!(description: "Cuisine service 2")
   )
 end
 


### PR DESCRIPTION
Allow wedding owner to create and edit service.

Change columns, introduce format `:datetime' for start_at and stop_at.

Adapt task show page, where services are listed.

Adapt services index page, for guests services.

Refactor services and tasks controller, and some css files when possible

TODO :
- improve service creation, gather creation of services with
same description.
- Add validations on models
- Allow wedding owner to destroy service, and modify existing tasks
- Improve how services are marked to 'complete' or 'uncomplete'